### PR TITLE
Improvements based on accessibility feedback

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -5,7 +5,7 @@
             <!-- wp:group {"metadata":{"name":"Left"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
                 <div class="wp-block-group">
                     <!-- wp:site-logo {"width":60,"shouldSyncIcon":false,"className":"is-style-rounded"} /-->
-                    <!-- wp:site-title /-->
+                    <!-- wp:site-title {"level":0,"className":"is-style-text-title"} /-->
                 </div>
             <!-- /wp:group -->
             <!-- wp:group {"metadata":{"name":"Right"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->

--- a/patterns/posts-list.php
+++ b/patterns/posts-list.php
@@ -16,15 +16,15 @@
 <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:paragraph {"className":"is-style-text-subtitle"} -->
-<p class="is-style-text-subtitle"><?php echo esc_html__( 'You may also enjoy…', 'kanso' ); ?></p>
-<!-- /wp:paragraph -->
+<!-- wp:heading {"className":"is-style-text-subtitle"} -->
+<h2 class="wp-block-heading is-style-text-subtitle"><?php echo esc_html__( 'You may also enjoy…', 'kanso' ); ?></h2>
+<!-- /wp:heading -->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":"20","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 <div class="wp-block-query"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"2px","bottom":"2px","left":"0px","right":"0px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-top:2px;padding-right:0px;padding-bottom:2px;padding-left:0px"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}},"typography":{"lineHeight":"1.2"}},"className":"no-underline truncate","fontSize":"large"} /-->
-
+<div class="wp-block-group" style="padding-top:2px;padding-right:0px;padding-bottom:2px;padding-left:0px">
+<!-- wp:post-title {"level":3,"isLink":true,"className":"no-underline truncate","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}},"typography":{"lineHeight":"1.2"}},"fontSize":"large"} /-->
 <!-- wp:post-date {"textAlign":"right","format":"M Y","style":{"typography":{"lineHeight":"1.2"}}} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>

--- a/style.css
+++ b/style.css
@@ -261,8 +261,8 @@ input:not([type=submit]):focus-visible {
 
 /* Navigation block */
 .wp-block-navigation .wp-block-navigation__submenu-container {
-    border-radius: var(--wp--preset--spacing--10);
-    padding: 12px 8px;
+	border-radius: var(--wp--preset--spacing--10);
+	padding: 12px 8px;
 }
 
 /* Dark mode toggle block */
@@ -272,7 +272,7 @@ input:not([type=submit]):focus-visible {
 }
 
 .wp-block-tabor-dark-mode-toggle__track:not(.has-background):hover {
-    background-color: var(--wp--preset--color--theme-4);
+	background-color: var(--wp--preset--color--theme-4);
 	color: var(--wp--preset--color--theme-6);
 }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,10 +2,11 @@
 
 <!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <main class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:group {"metadata":{"name":"Title"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
-<!-- wp:term-description /-->
-</div>
+<div class="wp-block-group"><!-- wp:heading {"level":1,"className":"is-style-text-title"} -->
+<h1 class="wp-block-heading is-style-text-title">Hi, I'm Rich Tabor</h1>
+<!-- /wp:heading -->
+
+<!-- wp:site-tagline /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"metadata":{"name":"Topics"},"layout":{"type":"default"}} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -58,14 +58,16 @@
 <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:paragraph {"className":"is-style-text-subtitle"} -->
-<p class="is-style-text-subtitle">You may also enjoy…</p>
-<!-- /wp:paragraph -->
+<!-- wp:heading {"className":"is-style-text-subtitle"} -->
+<h2 class="wp-block-heading is-style-text-subtitle">You may also enjoy…</h2>
+<!-- /wp:heading -->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":"60","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}}} -->
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"2px","bottom":"2px","left":"0px","right":"0px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-top:2px;padding-right:0px;padding-bottom:2px;padding-left:0px"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}},"typography":{"lineHeight":"1.2"}},"className":"no-underline truncate","fontSize":"large"} /-->
+<div class="wp-block-group" style="padding-top:2px;padding-right:0px;padding-bottom:2px;padding-left:0px">
+        
+<!-- wp:post-title {"level":3,"isLink":true,"className":"no-underline truncate","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}},"typography":{"lineHeight":"1.2"}},"fontSize":"large"} /-->
 
 <!-- wp:post-date {"textAlign":"right","format":"M Y"} /--></div>
 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -77,7 +77,7 @@
 					"slug": "theme-4"
 				},
 				{
-					"color": "color-mix(in srgb, var(--wp--preset--color--theme-1) 45%, var(--wp--preset--color--theme-6) 55%)",
+					"color": "color-mix(in srgb, var(--wp--preset--color--theme-1) 32%, var(--wp--preset--color--theme-6) 68%)",
 					"name": "Theme 5",
 					"slug": "theme-5"
 				},
@@ -94,7 +94,7 @@
 				"theme-2-dark": "color-mix(in srgb, var(--wp--preset--color--theme-1) 4%, var(--wp--preset--color--theme-6) 96%)",
 				"theme-3-dark": "color-mix(in srgb, var(--wp--preset--color--theme-1) 12%, var(--wp--preset--color--theme-6) 88%)",
 				"theme-4-dark": "color-mix(in srgb, var(--wp--preset--color--theme-1) 25%, var(--wp--preset--color--theme-6) 75%)",
-				"theme-5-dark": "color-mix(in srgb, var(--wp--preset--color--theme-1) 45%, var(--wp--preset--color--theme-6) 55%)",
+				"theme-5-dark": "color-mix(in srgb, var(--wp--preset--color--theme-1) 50%, var(--wp--preset--color--theme-6) 50%)",
 				"theme-6-dark": "hsl(0 0% 100% / 85%)"
 			},
 			"transition": {
@@ -851,6 +851,9 @@
 				":hover": {
 					"color": {
 						"text": "var(--wp--preset--color--theme-6)"
+					},
+					"typography": {
+						"textDecoration": "none"
 					}
 				},
 				"color": {


### PR DESCRIPTION
The only noticeable change is that the archive template will now render the title of the archive (the tag, category, etc) and the description (if there is one added to the tag, category, etc). 

![CleanShot 2024-11-22 at 13 33 50](https://github.com/user-attachments/assets/83f1a0b4-2197-4b9a-8bc4-3616c1517e8e)


Feedback reported: 

> 1. The site title is incorrectly marked as an H1, which results in
multiple H1s on pages and posts.
`<h1 class="wp-block-site-title" data-element-id="headingsMap-0-0"><a
href="https://reverent-cod-7b24ca.instawp.xyz/" target="_self" rel="home
">[wp-a11y-theme-test.instawp.xyz](http://wp-a11y-theme-test.instawp.xyz/)</a></h1>`
This should be marked as a paragraph rather than an H1 so that the post
title is the only H1 on the page.

> 2. The "You may also enjoy..." text on single posts is not marked as a
heading, though it should be and the blog posts below it have the
incorrect heading level set. This text should be an H2 instead of a paragraph and the blog posts below
it should be H3s instead of H2s.

> 3. The H1 on tag and category archive does not match the purpose of the
page. It stays as the hard-coded "Hi, I’m Rich Tabor" text. This should output the title of the category or tag.

> 4. Color contrast failures:
The color #7A7A7A on a white background has a contrast ratio of 4.3:1 and
fails contrast checks. 