### PR TITLE
Fix radio button style

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,7 +127,7 @@ label {
 }
 
 textarea,
-input:not([type=submit]):not([type=checkbox]) {
+input:not([type=submit]):not([type=checkbox]):not([type=radio]) {
 	background-color: color-mix(in srgb, var(--wp--preset--color--theme-1) 98%, var(--wp--preset--color--theme-6) 2%);
 	border-color: var(--wp--preset--color--theme-4);
 	border-radius: var(--wp--preset--spacing--10);


### PR DESCRIPTION
The change modifies the `input` selector to exclude `radio` input types from the specified styles.

**Before**

![image](https://github.com/user-attachments/assets/1ae83e09-e20f-45d9-87e4-94657244dfa7)

**After**

![image](https://github.com/user-attachments/assets/9783b06c-2d2c-4317-978a-b8f6ba6716e2)